### PR TITLE
Apple Clients v6.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bear_tracks"
-version = "6.1.0"
+version = "6.1.1"
 edition = "2021"
 authors = ["Jayen Agrawal"]
 description = "a scouting app for frc"

--- a/ios/TeamViewStats.swift
+++ b/ios/TeamViewStats.swift
@@ -95,8 +95,8 @@ struct TeamViewStats: View {
                         .frame(maxWidth: .infinity)
                         VStack {
                             Text("\(Int(((teamDetail.teamData[0].leave ?? 0) * 100).rounded()))%")
-                            Text("Auto Leave")
                                 .font(.title)
+                            Text("Auto Leave")
                         }
                         .frame(maxWidth: .infinity)
                         VStack {

--- a/ios/TeamViewStats.swift
+++ b/ios/TeamViewStats.swift
@@ -95,13 +95,14 @@ struct TeamViewStats: View {
                         .frame(maxWidth: .infinity)
                         VStack {
                             Text("\(Int(((teamDetail.teamData[0].leave ?? 0) * 100).rounded()))%")
-                            Text("Auto leave")
+                            Text("Auto Leave")
+                                .font(.title)
                         }
                         .frame(maxWidth: .infinity)
                         VStack {
                             Text("\(String(getRelevantData(item: teamDetail.teamData[0].auto_scores)))")
                                 .font(.title)
-                            Text("Auto scores")
+                            Text("Auto Scores")
                         }
                         .frame(maxWidth: .infinity)
                     }
@@ -129,9 +130,9 @@ struct TeamViewStats: View {
                     .padding([.top, .bottom])
                     HStack {
                         VStack {
-                            Text("\(String(getRelevantData(item: teamDetail.teamData[0].score))) pts")
+                            Text("\(String(getRelevantData(item: teamDetail.teamData[0].score)))")
                                 .font(.title)
-                            Text("Performance rating")
+                            Text("Performance Rating")
                         }
                         .frame(maxWidth: .infinity)
                     }

--- a/ios/TeamViewStats.swift
+++ b/ios/TeamViewStats.swift
@@ -61,6 +61,33 @@ struct TeamViewStats: View {
                     .padding([.top, .bottom])
                     HStack {
                         VStack {
+                            Text("\(String(getRelevantData(item: teamDetail.teamData[0].level_0)))")
+                                .font(.title)
+                            Text("L1")
+                        }
+                        .frame(maxWidth: .infinity)
+                        VStack {
+                            Text("\(String(getRelevantData(item: teamDetail.teamData[0].level_1)))")
+                                .font(.title)
+                            Text("L2")
+                        }
+                        .frame(maxWidth: .infinity)
+                        VStack {
+                            Text("\(String(getRelevantData(item: teamDetail.teamData[0].level_2)))")
+                                .font(.title)
+                            Text("L3")
+                        }
+                        .frame(maxWidth: .infinity)
+                        VStack {
+                            Text("\(String(getRelevantData(item: teamDetail.teamData[0].level_3)))")
+                                .font(.title)
+                            Text("L4")
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                    .padding([.top, .bottom])
+                    HStack {
+                        VStack {
                             Text("\(String(getRelevantData(item: teamDetail.teamData[0].algae)))")
                                 .font(.title)
                             Text("Algae")

--- a/ios/TeamViewStats.swift
+++ b/ios/TeamViewStats.swift
@@ -94,9 +94,8 @@ struct TeamViewStats: View {
                         }
                         .frame(maxWidth: .infinity)
                         VStack {
-                            Text("\(String(getRelevantData(item: teamDetail.teamData[0].level_0) + getRelevantData(item: teamDetail.teamData[0].level_1) + getRelevantData(item: teamDetail.teamData[0].level_2) + getRelevantData(item: teamDetail.teamData[0].level_3)))")
-                                .font(.title)
-                            Text("Coral")
+                            Text("\(Int(((teamDetail.teamData[0].leave ?? 0) * 100).rounded()))%")
+                            Text("Auto leave")
                         }
                         .frame(maxWidth: .infinity)
                         VStack {
@@ -111,7 +110,7 @@ struct TeamViewStats: View {
                         VStack {
                             Text("\(Int(((teamDetail.teamData[0].shallow_cage ?? 0) * 100).rounded()))%")
                                 .font(.title)
-                            Text("Cage")
+                            Text("Shallow Cage")
                         }
                         .frame(maxWidth: .infinity)
                         VStack {

--- a/ios/beartracks/bearTracks.xcodeproj/project.pbxproj
+++ b/ios/beartracks/bearTracks.xcodeproj/project.pbxproj
@@ -569,14 +569,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 106;
+				CURRENT_PROJECT_VERSION = 107;
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "sitckers StickerPackExtension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = bearTracks;
 				INFOPLIST_KEY_NSStickerSharingLevel = OS;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 6.1.1;
+				MARKETING_VERSION = 6.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks.stickers;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -593,14 +593,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 106;
+				CURRENT_PROJECT_VERSION = 107;
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "sitckers StickerPackExtension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = bearTracks;
 				INFOPLIST_KEY_NSStickerSharingLevel = OS;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 6.1.1;
+				MARKETING_VERSION = 6.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks.stickers;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -616,7 +616,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 106;
+				CURRENT_PROJECT_VERSION = 107;
 				DEVELOPMENT_ASSET_PATHS = "\"beartracks-matches/Preview Content\"";
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				ENABLE_PREVIEWS = YES;
@@ -629,7 +629,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.1;
+				MARKETING_VERSION = 6.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -646,7 +646,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 106;
+				CURRENT_PROJECT_VERSION = 107;
 				DEVELOPMENT_ASSET_PATHS = "\"beartracks-matches/Preview Content\"";
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				ENABLE_PREVIEWS = YES;
@@ -659,7 +659,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.1;
+				MARKETING_VERSION = 6.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -797,7 +797,7 @@
 				CODE_SIGN_ENTITLEMENTS = bearTracks/bearTracks.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 106;
+				CURRENT_PROJECT_VERSION = 107;
 				DEVELOPMENT_ASSET_PATHS = "\"bearTracks/Preview Content\"";
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				ENABLE_PREVIEWS = YES;
@@ -818,7 +818,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.1;
+				MARKETING_VERSION = 6.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -842,7 +842,7 @@
 				CODE_SIGN_ENTITLEMENTS = bearTracks/bearTracks.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 106;
+				CURRENT_PROJECT_VERSION = 107;
 				DEVELOPMENT_ASSET_PATHS = "\"bearTracks/Preview Content\"";
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				ENABLE_PREVIEWS = YES;
@@ -863,7 +863,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.1;
+				MARKETING_VERSION = 6.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -886,7 +886,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "beartracks-watch Watch App/beartracks-watch Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 106;
+				CURRENT_PROJECT_VERSION = 107;
 				DEVELOPMENT_ASSET_PATHS = "\"beartracks-watch Watch App/Preview Content\"";
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				ENABLE_PREVIEWS = YES;
@@ -899,7 +899,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.1;
+				MARKETING_VERSION = 6.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -918,7 +918,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "beartracks-watch Watch App/beartracks-watch Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 106;
+				CURRENT_PROJECT_VERSION = 107;
 				DEVELOPMENT_ASSET_PATHS = "\"beartracks-watch Watch App/Preview Content\"";
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				ENABLE_PREVIEWS = YES;
@@ -931,7 +931,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.1;
+				MARKETING_VERSION = 6.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;

--- a/ios/beartracks/bearTracks.xcodeproj/project.pbxproj
+++ b/ios/beartracks/bearTracks.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		F54E76C22B527D96003C65A2 /* bearTracksApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E76C12B527D96003C65A2 /* bearTracksApp.swift */; };
 		F54E76C62B527D97003C65A2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F54E76C52B527D97003C65A2 /* Assets.xcassets */; };
 		F54E76C92B527D97003C65A2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F54E76C82B527D97003C65A2 /* Preview Assets.xcassets */; };
+		F56BFF4C2D9CCC2C00E0CFF7 /* TeamHistoryGraphData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56BFF4B2D9CCC2C00E0CFF7 /* TeamHistoryGraphData.swift */; };
+		F56BFF4E2D9CD1A500E0CFF7 /* TeamHistoryGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56BFF4D2D9CD1A500E0CFF7 /* TeamHistoryGraph.swift */; };
 		F597AFFE2D6E74E0006CF1A5 /* CarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F597AFFD2D6E74CF006CF1A5 /* CarouselView.swift */; };
 		F597B0002D6E778D006CF1A5 /* CarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F597AFFD2D6E74CF006CF1A5 /* CarouselView.swift */; };
 		F59F8F7B2B7D292700D35A56 /* TeamViewStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59F8F7A2B7D292700D35A56 /* TeamViewStats.swift */; };
@@ -139,6 +141,8 @@
 		F54E76C12B527D96003C65A2 /* bearTracksApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = bearTracksApp.swift; sourceTree = "<group>"; };
 		F54E76C52B527D97003C65A2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F54E76C82B527D97003C65A2 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		F56BFF4B2D9CCC2C00E0CFF7 /* TeamHistoryGraphData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamHistoryGraphData.swift; sourceTree = "<group>"; };
+		F56BFF4D2D9CD1A500E0CFF7 /* TeamHistoryGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamHistoryGraph.swift; sourceTree = "<group>"; };
 		F597AFFD2D6E74CF006CF1A5 /* CarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselView.swift; sourceTree = "<group>"; };
 		F59F8F7A2B7D292700D35A56 /* TeamViewStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TeamViewStats.swift; path = ../../TeamViewStats.swift; sourceTree = "<group>"; };
 		F59F8F7C2B7D2AD600D35A56 /* TeamStatController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamStatController.swift; sourceTree = "<group>"; };
@@ -252,13 +256,15 @@
 				F5AE2E4E2B527E170033DB0D /* SettingsManager.swift */,
 				F5AE2E522B527E170033DB0D /* SettingsView.swift */,
 				F5AE2E4D2B527E170033DB0D /* Teams.swift */,
+				F59F8F7A2B7D292700D35A56 /* TeamViewStats.swift */,
 				F59F8F7C2B7D2AD600D35A56 /* TeamStatController.swift */,
 				F540A13C2B549D2500611384 /* TeamView.swift */,
 				F540A13E2B549D2E00611384 /* TeamViewModel.swift */,
+				F56BFF4D2D9CD1A500E0CFF7 /* TeamHistoryGraph.swift */,
+				F56BFF4B2D9CCC2C00E0CFF7 /* TeamHistoryGraphData.swift */,
 				F5475D8C2D53CC0D00E81F49 /* PitDataView.swift */,
 				F5475D902D53CCCE00E81F49 /* PitDataController.swift */,
 				F597AFFD2D6E74CF006CF1A5 /* CarouselView.swift */,
-				F59F8F7A2B7D292700D35A56 /* TeamViewStats.swift */,
 				F532B0322D4BE6D900B7C127 /* RegionalPoints.swift */,
 				F5C9B83F2D7FA1090069A64A /* AllianceSimulator.swift */,
 				F5C9B8412D7FA2710069A64A /* AllianceSelection.swift */,
@@ -487,6 +493,7 @@
 				F5AE2E532B527E170033DB0D /* Teams.swift in Sources */,
 				F59F8F7B2B7D292700D35A56 /* TeamViewStats.swift in Sources */,
 				F5475D8E2D53CC0D00E81F49 /* PitDataView.swift in Sources */,
+				F56BFF4E2D9CD1A500E0CFF7 /* TeamHistoryGraph.swift in Sources */,
 				F5AE2E5A2B5288FB0033DB0D /* URLSessionConfiguration.swift in Sources */,
 				F54E76C22B527D96003C65A2 /* bearTracksApp.swift in Sources */,
 				F5AE2E5E2B52FF3F0033DB0D /* LoginView.swift in Sources */,
@@ -494,6 +501,7 @@
 				F5AE2E472B527E050033DB0D /* DetailedView.swift in Sources */,
 				F540A13F2B549D2E00611384 /* TeamViewModel.swift in Sources */,
 				F5AE2E582B527E170033DB0D /* SettingsView.swift in Sources */,
+				F56BFF4C2D9CCC2C00E0CFF7 /* TeamHistoryGraphData.swift in Sources */,
 				F5AE2E542B527E170033DB0D /* SettingsManager.swift in Sources */,
 				F5475D912D53CCCE00E81F49 /* PitDataController.swift in Sources */,
 				F59F8F7D2B7D2AD600D35A56 /* TeamStatController.swift in Sources */,
@@ -561,14 +569,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "sitckers StickerPackExtension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = bearTracks;
 				INFOPLIST_KEY_NSStickerSharingLevel = OS;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 6.1.0;
+				MARKETING_VERSION = 6.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks.stickers;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -585,14 +593,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "sitckers StickerPackExtension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = bearTracks;
 				INFOPLIST_KEY_NSStickerSharingLevel = OS;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 6.1.0;
+				MARKETING_VERSION = 6.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks.stickers;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -608,7 +616,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				DEVELOPMENT_ASSET_PATHS = "\"beartracks-matches/Preview Content\"";
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				ENABLE_PREVIEWS = YES;
@@ -621,7 +629,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.0;
+				MARKETING_VERSION = 6.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -638,7 +646,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				DEVELOPMENT_ASSET_PATHS = "\"beartracks-matches/Preview Content\"";
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				ENABLE_PREVIEWS = YES;
@@ -651,7 +659,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.0;
+				MARKETING_VERSION = 6.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -789,7 +797,7 @@
 				CODE_SIGN_ENTITLEMENTS = bearTracks/bearTracks.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				DEVELOPMENT_ASSET_PATHS = "\"bearTracks/Preview Content\"";
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				ENABLE_PREVIEWS = YES;
@@ -810,7 +818,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.0;
+				MARKETING_VERSION = 6.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -834,7 +842,7 @@
 				CODE_SIGN_ENTITLEMENTS = bearTracks/bearTracks.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				DEVELOPMENT_ASSET_PATHS = "\"bearTracks/Preview Content\"";
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				ENABLE_PREVIEWS = YES;
@@ -855,7 +863,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.0;
+				MARKETING_VERSION = 6.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -878,7 +886,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "beartracks-watch Watch App/beartracks-watch Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				DEVELOPMENT_ASSET_PATHS = "\"beartracks-watch Watch App/Preview Content\"";
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				ENABLE_PREVIEWS = YES;
@@ -891,7 +899,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.0;
+				MARKETING_VERSION = 6.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -910,7 +918,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "beartracks-watch Watch App/beartracks-watch Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				DEVELOPMENT_ASSET_PATHS = "\"beartracks-watch Watch App/Preview Content\"";
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				ENABLE_PREVIEWS = YES;
@@ -923,7 +931,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.0;
+				MARKETING_VERSION = 6.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayagra.beartracks.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;

--- a/ios/beartracks/bearTracks/AllianceSimulator.swift
+++ b/ios/beartracks/bearTracks/AllianceSimulator.swift
@@ -579,31 +579,6 @@ struct BarThingyViewAlliance: View {
     }
 }
 
-public struct AllTeamsList: Codable {
-    let status: Int
-    let teams: [BasicTeam]
-}
-
-public struct BasicTeam: Codable {
-    let number: Int
-    let nameShort: String
-}
-
-struct TeamList: Codable {
-    let teamCountTotal, teamCountPage: Int
-    let pageCurrent, pageTotal: Int
-    let teams: [TeamListTeamEntry]
-}
-
-struct TeamListTeamEntry: Codable {
-    let teamNumber: Int
-    let nameFull, nameShort: String
-    let city, stateProv, country: String
-    let rookieYear: Int
-    let robotName, schoolName, website: String
-    let homeCMP: String?
-}
-
 #Preview {
     AllianceSimulator()
 }

--- a/ios/beartracks/bearTracks/MatchDetailView.swift
+++ b/ios/beartracks/bearTracks/MatchDetailView.swift
@@ -25,9 +25,6 @@ struct MatchDetailView: View {
             if appState.matchJson.count != 0 && appState.matchJson.count >= match {
                 if teams.count == 6 {
                     ScrollView {
-                        Text("Match \(String(match))")
-                            .font(.largeTitle)
-                            .padding()
                         Text("+\(calculateWinner().0)%")
                             .font(.title)
                             .foregroundStyle(calculateWinner().1 ? Color.red : Color.blue)

--- a/ios/beartracks/bearTracks/MatchList.swift
+++ b/ios/beartracks/bearTracks/MatchList.swift
@@ -17,38 +17,60 @@ struct MatchList: View {
             if !appState.matchJson.isEmpty {
                 List {
                     ForEach(Array(appState.matchJson.enumerated()), id: \.element.id) { index, match in
-                        NavigationLink(tag: index, selection: self.$selectedMatch, destination: {
-                            MatchDetailView(match: match.matchNumber)
-                                .navigationTitle("Match \(match.matchNumber)")
-                                .environmentObject(appState)
-                        }, label: {
-                            VStack {
-                                Text(String(match.description))
-                                    .font(.title3)
-                                HStack {
-                                    Spacer()
-                                    TeamNumberStack(match: match, num: 0)
-                                    Spacer()
-                                    TeamNumberStack(match: match, num: 1)
-                                    Spacer()
-                                    TeamNumberStack(match: match, num: 2)
-                                    Spacer()
+                        if !myTeamOnly || match.teams.contains(where: { $0.teamNumber == Int(UserDefaults().string(forKey: "teamNumber") ?? "766") ?? 766 }) {
+                            NavigationLink(tag: index, selection: self.$selectedMatch, destination: {
+                                MatchDetailView(match: match.matchNumber)
+                                    .navigationTitle("Match \(match.matchNumber)")
+                                    .environmentObject(appState)
+                            }, label: {
+                                VStack {
+                                    Text(String(match.description))
+                                        .font(.title3)
+                                    HStack {
+                                        Spacer()
+                                        TeamNumberStack(match: match, num: 0)
+                                        Spacer()
+                                        TeamNumberStack(match: match, num: 1)
+                                        Spacer()
+                                        TeamNumberStack(match: match, num: 2)
+                                        Spacer()
+                                    }
                                 }
-                            }
 #if targetEnvironment(macCatalyst)
-                            .padding(.vertical)
+                                .padding(.vertical)
 #endif
-                        })
+                            })
 #if os(iOS)
-                        .listRowBackground(UIDevice.current.userInterfaceIdiom == .pad ? Color.primary.colorInvert() : nil)
+                            .listRowBackground(UIDevice.current.userInterfaceIdiom == .pad ? Color.primary.colorInvert() : nil)
 #elseif targetEnvironment(macCatalyst)
-                        .listRowBackground(Color.primary.colorInvert())
+                            .listRowBackground(Color.primary.colorInvert())
 #endif
+                        }
                     }
                 }
                 .refreshable { appState.fetchMatchJson() }
                 .onAppear { appState.fetchMatchJson() }
                 .navigationTitle("Matches")
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button(action: {
+                            self.myTeamOnly.toggle()
+                        }, label: {
+                            if !appState.matchJson.isEmpty {
+                                if myTeamOnly {
+                                    Label("Show Mine", systemImage: "line.3.horizontal.decrease.circle.fill")
+                                        .labelStyle(.iconOnly)
+                                } else {
+                                    Label("Show All", systemImage: "line.3.horizontal.decrease.circle")
+                                        .labelStyle(.iconOnly)
+                                }
+                            } else {
+                                Label("Loading...", systemImage: "hourglass")
+                                    .labelStyle(.iconOnly)
+                            }
+                        })
+                    }
+                }
             } else {
                 if appState.matchJsonStatus.1 {
                     VStack {
@@ -92,26 +114,6 @@ struct MatchList: View {
                 }
             }
         }
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button(action: {
-                    self.myTeamOnly.toggle()
-                }, label: {
-                    if !appState.matchJson.isEmpty {
-                        if myTeamOnly {
-                            Label("Show Mine", systemImage: "line.3.horizontal.decrease.circle.fill")
-                                .labelStyle(.iconOnly)
-                        } else {
-                            Label("Show All", systemImage: "line.3.horizontal.decrease.circle")
-                                .labelStyle(.iconOnly)
-                        }
-                    } else {
-                        Label("Loading...", systemImage: "hourglass")
-                            .labelStyle(.iconOnly)
-                    }
-                })
-            }
-        }
     }
 }
 
@@ -129,7 +131,7 @@ struct TeamNumberStack: View {
 #if os(visionOS)
                 .font(.title2)
 #else
-                .font(UIDevice.current.userInterfaceIdiom == .pad ? .title2 : .largeTitle)
+                .font(UIDevice.current.userInterfaceIdiom == .pad ? .title3 : .title)
 #endif
                 .fontWeight(
                     String(match.teams[num].teamNumber)
@@ -141,7 +143,7 @@ struct TeamNumberStack: View {
 #if os(visionOS)
                 .font(.title2)
 #else
-                .font(UIDevice.current.userInterfaceIdiom == .pad ? .title2 : .largeTitle)
+                .font(UIDevice.current.userInterfaceIdiom == .pad ? .title3 : .title)
 #endif
                 .fontWeight(
                     String(match.teams[num + 3].teamNumber)

--- a/ios/beartracks/bearTracks/PitDataView.swift
+++ b/ios/beartracks/bearTracks/PitDataView.swift
@@ -68,13 +68,13 @@ struct PitDataView: View {
                                 }
                                 Section {
                                     Text("Team's Estimations").bold()
-                                    PitDataIntViewer(data: mergedData.estimated_cycles, textOptions: mergedData.estimated_cycles.map { String($0) }, label: "Cycles/Game", mergedData: mergedData)
-                                    PitDataIntViewer(data: mergedData.estimated_cycles, textOptions: mergedData.auto_algae.map { String($0) }, label: "Auto Algae", mergedData: mergedData)
-                                    PitDataIntViewer(data: mergedData.estimated_cycles, textOptions: mergedData.auto_coral.map { String($0) }, label: "Auto Coral", mergedData: mergedData)
+                                    PitDataIntViewer(data: mergedData.estimated_cycles.indices.map { $0 }, textOptions: mergedData.estimated_cycles.map { String($0) }, label: "Cycles/Game", mergedData: mergedData)
+                                    PitDataIntViewer(data: mergedData.estimated_cycles.indices.map { $0 }, textOptions: mergedData.auto_algae.map { String($0) }, label: "Auto Algae", mergedData: mergedData)
+                                    PitDataIntViewer(data: mergedData.estimated_cycles.indices.map { $0 }, textOptions: mergedData.auto_coral.map { String($0) }, label: "Auto Coral", mergedData: mergedData)
                                 }
                                 Section {
                                     ForEach(mergedData.notes.indices, id: \.self) { index in
-                                        Text("\(mergedData.notes[index])\n\n\(mergedData.name[index]) (\(String(mergedData.from_team[index]))")
+                                        Text("\(mergedData.notes[index])\n\n\(mergedData.name[index]) (\(String(mergedData.from_team[index])))")
                                     }
                                 }
                                 CarouselView(imagesUrls: mergedData.image_ids)

--- a/ios/beartracks/bearTracks/PitDataView.swift
+++ b/ios/beartracks/bearTracks/PitDataView.swift
@@ -180,7 +180,7 @@ struct PitDataIntViewer: View {
                         HStack {
                             Text(String("\(mergedData.id[index]) • \(mergedData.name[index]) (\(mergedData.from_team[index]))"))
                             Spacer()
-                            Text(String(textOptions[index]))
+                            Text(String(textOptions[safe: index] ?? "Invalid Data"))
                         }
                     }
                 }
@@ -195,7 +195,7 @@ struct PitDataIntViewer: View {
             HStack {
                 Text(label)
                 Spacer()
-                Label(String(textOptions[0]), systemImage: "exclamationmark.triangle.fill")
+                Label(String(textOptions[safe: data.first ?? 255] ?? "Invalid Data"), systemImage: "exclamationmark.triangle.fill")
                     .labelStyle(.titleOnly)
             }
         }
@@ -204,4 +204,10 @@ struct PitDataIntViewer: View {
 
 #Preview {
     PitDataView(teamNumber: 766)
+}
+
+extension Collection {
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
 }

--- a/ios/beartracks/bearTracks/SettingsView.swift
+++ b/ios/beartracks/bearTracks/SettingsView.swift
@@ -74,6 +74,7 @@ struct SettingsView: View {
                         }
                         .pickerStyle(.navigationLink)
                         .onChange(of: eventCodeInput) { value in
+                            appState.fetchTeamsJson()
                             UserDefaults().set(eventCodeInput, forKey: "eventCode")
                         }
                     } else {
@@ -92,6 +93,7 @@ struct SettingsView: View {
                         .pickerStyle(.menu)
 #endif
                         .onChange(of: eventCodeInput) { value in
+                            appState.fetchTeamsJson()
                             UserDefaults().set(eventCodeInput, forKey: "eventCode")
                         }
                     }

--- a/ios/beartracks/bearTracks/SettingsView.swift
+++ b/ios/beartracks/bearTracks/SettingsView.swift
@@ -25,39 +25,75 @@ struct SettingsView: View {
         NavigationView {
             Form {
                 Section {
-                    Picker("Team Number", selection: $teamNumberInput) {
-                        if !settingsOptions.isEmpty {
-                            ForEach(settingsOptions[0].teams, id: \.self) { team in
-                                Text(team)
-                                    .tag(team)
+                    if #available(iOS 16.0, *) {
+                        Picker("Team Number", selection: $teamNumberInput) {
+                            if !settingsOptions.isEmpty {
+                                ForEach(settingsOptions[0].teams, id: \.self) { team in
+                                    Text(team)
+                                        .tag(team)
+                                }
+                            } else {
+                                Text(teamNumberInput)
+                                    .tag(teamNumberInput)
                             }
-                        } else {
-                            Text(teamNumberInput)
-                                .tag(teamNumberInput)
+                        }
+                        .pickerStyle(.navigationLink)
+                        .onChange(of: teamNumberInput) { value in
+                            UserDefaults().set(teamNumberInput, forKey: "teamNumber")
+                        }
+                    } else {
+                        Picker("Team Number", selection: $teamNumberInput) {
+                            if !settingsOptions.isEmpty {
+                                ForEach(settingsOptions[0].teams, id: \.self) { team in
+                                    Text(team)
+                                        .tag(team)
+                                }
+                            } else {
+                                Text(teamNumberInput)
+                                    .tag(teamNumberInput)
+                            }
+                        }
+#if !os(watchOS)
+                        .pickerStyle(.menu)
+#endif
+                        .onChange(of: teamNumberInput) { value in
+                            UserDefaults().set(teamNumberInput, forKey: "teamNumber")
                         }
                     }
-#if !os(watchOS)
-                    .pickerStyle(.menu)
-#endif
-                    .onChange(of: teamNumberInput) { value in
-                        UserDefaults().set(teamNumberInput, forKey: "teamNumber")
-                    }
-                    Picker("Event Code", selection: $eventCodeInput) {
-                        if !settingsOptions.isEmpty {
-                            ForEach(settingsOptions[0].events, id: \.self) { event_code in
-                                Text(event_code)
-                                    .tag(event_code)
+                    if #available(iOS 16.0, *) {
+                        Picker("Event Code", selection: $eventCodeInput) {
+                            if !settingsOptions.isEmpty {
+                                ForEach(settingsOptions[0].events, id: \.self) { event_code in
+                                    Text(event_code)
+                                        .tag(event_code)
+                                }
+                            } else {
+                                Text(eventCodeInput)
+                                    .tag(eventCodeInput)
                             }
-                        } else {
-                            Text(eventCodeInput)
-                                .tag(eventCodeInput)
                         }
-                    }
+                        .pickerStyle(.navigationLink)
+                        .onChange(of: eventCodeInput) { value in
+                            UserDefaults().set(eventCodeInput, forKey: "eventCode")
+                        }
+                    } else {
+                        Picker("Event Code", selection: $eventCodeInput) {
+                            if !settingsOptions.isEmpty {
+                                ForEach(settingsOptions[0].events, id: \.self) { event_code in
+                                    Text(event_code)
+                                        .tag(event_code)
+                                }
+                            } else {
+                                Text(eventCodeInput)
+                                    .tag(eventCodeInput)
+                            }
+                        }
 #if !os(watchOS)
-                    .pickerStyle(.menu)
+                        .pickerStyle(.menu)
 #endif
-                    .onChange(of: eventCodeInput) { value in
-                        UserDefaults().set(eventCodeInput, forKey: "eventCode")
+                        .onChange(of: eventCodeInput) { value in
+                            UserDefaults().set(eventCodeInput, forKey: "eventCode")
+                        }
                     }
                     Picker("Season", selection: $seasonInput) {
                         if !settingsOptions.isEmpty {
@@ -74,8 +110,7 @@ struct SettingsView: View {
                     .pickerStyle(.menu)
 #endif
                     .onChange(of: seasonInput) { value in
-                        UserDefaults().set(
-                            seasonInput, forKey: "season")
+                        UserDefaults().set(seasonInput, forKey: "season")
                     }
                 }
                 Section {

--- a/ios/beartracks/bearTracks/TeamHistoryGraph.swift
+++ b/ios/beartracks/bearTracks/TeamHistoryGraph.swift
@@ -1,0 +1,136 @@
+//
+//  TeamHistoryGraph.swift
+//  bearTracks
+//
+//  Created by Jayen Agrawal on 4/1/25.
+//
+
+import SwiftUI
+import Charts
+
+@available(iOS 18.0, *)
+struct TeamHistoryGraph: View {
+    private var teamNumber: Int
+    @ObservedObject var teamGraphs: TeamHistoryGraphData
+    @State private var data: [Int: [Double]] = [:]
+    
+    init(teamNumber: Int) {
+        self.teamNumber = teamNumber
+        self.teamGraphs = TeamHistoryGraphData(teamNumber: teamNumber)
+    }
+    
+    var body: some View {
+        VStack {
+            if !data.isEmpty {
+                ScrollView {
+                    Text("Level 1 Coral").font(.title2).padding([.horizontal, .top])
+                    Chart {
+                        ForEach(sortedData(), id: \.0) { key, value in
+                            LineMark(
+                                x: .value("Match", key),
+                                y: .value("Level 1", value[8])
+                            )
+                        }
+                    }.padding([.horizontal, .bottom]).chartYScale(domain: 0...1)
+                    Text("Level 2 Coral").font(.title2).padding([.horizontal, .top])
+                    Chart {
+                        ForEach(sortedData(), id: \.0) { key, value in
+                            LineMark(
+                                x: .value("Match", key),
+                                y: .value("Level 2", value[9])
+                            )
+                        }
+                    }.padding([.horizontal, .bottom]).chartYScale(domain: 0...1)
+                    Text("Level 3 Coral").font(.title2).padding([.horizontal, .top])
+                    Chart {
+                        ForEach(sortedData(), id: \.0) { key, value in
+                            LineMark(
+                                x: .value("Match", key),
+                                y: .value("Level 3", value[10])
+                            )
+                        }
+                    }.padding([.horizontal, .bottom]).chartYScale(domain: 0...1)
+                    Text("Level 4 Coral").font(.title2).padding([.horizontal, .top])
+                    Chart {
+                        ForEach(sortedData(), id: \.0) { key, value in
+                            LineMark(
+                                x: .value("Match", key),
+                                y: .value("Level 4", value[11])
+                            )
+                        }
+                    }.padding([.horizontal, .bottom]).chartYScale(domain: 0...1)
+                    Text("Algae").font(.title2).padding([.horizontal, .top])
+                    Chart {
+                        ForEach(sortedData(), id: \.0) { key, value in
+                            LineMark(
+                                x: .value("Match", key),
+                                y: .value("Algae", value[7])
+                            )
+                        }
+                    }.padding([.horizontal, .bottom]).chartYScale(domain: 0...1)
+                    Text("Auto Leave").font(.title2).padding([.horizontal, .top])
+                    Chart {
+                        ForEach(sortedData(), id: \.0) { key, value in
+                            LineMark(
+                                x: .value("Match", key),
+                                y: .value("Yes/No", value[0])
+                            )
+                        }
+                    }.padding([.horizontal, .bottom]).chartYScale(domain: 0...1)
+                    Text("Shallow Cage").font(.title2).padding([.horizontal, .top])
+                    Chart {
+                        ForEach(sortedData(), id: \.0) { key, value in
+                            LineMark(
+                                x: .value("Match", key),
+                                y: .value("Yes/No", value[2])
+                            )
+                        }
+                    }.padding([.horizontal, .bottom]).chartYScale(domain: 0...1)
+                    Text("Deep Cage").font(.title2).padding([.horizontal, .top])
+                    Chart {
+                        ForEach(sortedData(), id: \.0) { key, value in
+                            LineMark(
+                                x: .value("Match", key),
+                                y: .value("Yes/No", value[3])
+                            )
+                        }
+                    }.padding([.horizontal, .bottom]).chartYScale(domain: 0...1)
+                }
+            } else {
+                if teamGraphs.briefData.isEmpty {
+                    Spacer()
+                    Text("Loading Team Data...")
+                        .onAppear {
+                            teamGraphs.fetchDataJson()
+                        }
+                    Spacer()
+                } else if !teamGraphs.briefData.isEmpty && data.isEmpty {
+                    Spacer()
+                    Text("Processing Team Data...")
+                        .onAppear {
+                            teamGraphs.processData(briefDataList: teamGraphs.briefData) { result in
+                                data = result
+                            }
+                        }
+                    Spacer()
+                } else {
+                    Spacer()
+                    Text("Error: Illegal State Change!")
+                    Spacer()
+                }
+            }
+        }
+    }
+    
+    private func sortedData() -> [(key: Int, value: [Double])] {
+        return data.sorted { $0.key < $1.key }
+    }
+}
+
+#Preview {
+    if #available(iOS 18.0, *) {
+        TeamHistoryGraph(teamNumber: 766)
+    } else {
+        Text("Only available on iOS 18 and later.")
+    }
+}

--- a/ios/beartracks/bearTracks/TeamHistoryGraph.swift
+++ b/ios/beartracks/bearTracks/TeamHistoryGraph.swift
@@ -31,7 +31,7 @@ struct TeamHistoryGraph: View {
                                 y: .value("Level 1", value[8])
                             )
                         }
-                    }.padding([.horizontal, .bottom]).chartYScale(domain: 0...1)
+                    }.padding([.horizontal, .bottom])
                     Text("Level 2 Coral").font(.title2).padding([.horizontal, .top])
                     Chart {
                         ForEach(sortedData(), id: \.0) { key, value in
@@ -40,7 +40,7 @@ struct TeamHistoryGraph: View {
                                 y: .value("Level 2", value[9])
                             )
                         }
-                    }.padding([.horizontal, .bottom]).chartYScale(domain: 0...1)
+                    }.padding([.horizontal, .bottom])
                     Text("Level 3 Coral").font(.title2).padding([.horizontal, .top])
                     Chart {
                         ForEach(sortedData(), id: \.0) { key, value in
@@ -49,7 +49,7 @@ struct TeamHistoryGraph: View {
                                 y: .value("Level 3", value[10])
                             )
                         }
-                    }.padding([.horizontal, .bottom]).chartYScale(domain: 0...1)
+                    }.padding([.horizontal, .bottom])
                     Text("Level 4 Coral").font(.title2).padding([.horizontal, .top])
                     Chart {
                         ForEach(sortedData(), id: \.0) { key, value in
@@ -58,7 +58,7 @@ struct TeamHistoryGraph: View {
                                 y: .value("Level 4", value[11])
                             )
                         }
-                    }.padding([.horizontal, .bottom]).chartYScale(domain: 0...1)
+                    }.padding([.horizontal, .bottom])
                     Text("Algae").font(.title2).padding([.horizontal, .top])
                     Chart {
                         ForEach(sortedData(), id: \.0) { key, value in
@@ -67,7 +67,7 @@ struct TeamHistoryGraph: View {
                                 y: .value("Algae", value[7])
                             )
                         }
-                    }.padding([.horizontal, .bottom]).chartYScale(domain: 0...1)
+                    }.padding([.horizontal, .bottom])
                     Text("Auto Leave").font(.title2).padding([.horizontal, .top])
                     Chart {
                         ForEach(sortedData(), id: \.0) { key, value in

--- a/ios/beartracks/bearTracks/TeamHistoryGraphData.swift
+++ b/ios/beartracks/bearTracks/TeamHistoryGraphData.swift
@@ -1,0 +1,108 @@
+//
+//  TeamHistoryGraphData.swift
+//  bearTracks
+//
+//  Created by Jayen Agrawal on 4/1/25.
+//
+
+import Foundation
+import Charts
+
+@available(iOS 18.0, *)
+class TeamHistoryGraphData: ObservableObject {
+    private var teamNumber: Int
+    @Published public var briefData: [DataEntry] = []
+    
+    init(teamNumber: Int) {
+        self.teamNumber = teamNumber
+    }
+    
+    func fetchDataJson() {
+        guard let url = URL(string: "https://beartracks.io/api/v1/data/brief/team/\(UserDefaults().string(forKey: "season") ?? "2025")/\(UserDefaults().string(forKey: "eventCode") ?? "TEST")/\(String(teamNumber))") else { return }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.httpShouldHandleCookies = true
+        
+        let requestTask = sharedSession.dataTask(with: request) { (data: Data?, response: URLResponse?, error: Error?) in
+            if let data = data {
+                do {
+                    let decoder = JSONDecoder()
+                    let result = try decoder.decode([DataEntry].self, from: data)
+                    DispatchQueue.main.async {
+                        DispatchQueue.main.async {
+                            self.briefData = result
+                        }
+                    }
+                } catch {
+                    print("parse error")
+                    DispatchQueue.main.async {
+                        self.briefData = []
+                    }
+                }
+            } else if let error = error {
+                print("fetch error: \(error)")
+                DispatchQueue.main.async {
+                    self.briefData = []
+                }
+            }
+        }
+        requestTask.resume()
+    }
+    
+    func getFullData(id: Int, completion: @escaping (FullMainData?) -> Void) {
+        let urlString = "https://beartracks.io/api/v1/data/detail/\(id)"
+        guard let url = URL(string: urlString) else { return }
+        
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            if let error = error {
+                print("error fetching data: \(error)")
+                completion(nil)
+                return
+            }
+            guard let data = data else {completion(nil); return }
+            do {
+                let decoder = JSONDecoder()
+                let fullMainData = try decoder.decode([DetailedData].self, from: data)
+                completion(fullMainData.first?.FullMain ?? nil)
+            } catch {
+                print("error decoding data: \(error)")
+                completion(nil)
+            }
+        }
+        task.resume()
+    }
+    
+    func processData(briefDataList: [DataEntry], completion: @escaping ([Int: [Double]]) -> Void) {
+        var matchData = [Int: [Double]]()
+        var matchCount = [Int: Int]()
+        
+        let dispatchGroup = DispatchGroup()
+        
+        for briefData in briefDataList {
+            dispatchGroup.enter()
+            getFullData(id: briefData.Brief.id) { fullMainData in
+                guard let fullMainData = fullMainData else { dispatchGroup.leave(); return }
+                let analysisValues = fullMainData.analysis.split(separator: ",").compactMap { Int($0) }
+                if matchData[fullMainData.match_num] == nil {
+                    matchData[fullMainData.match_num] = Array(repeating: 0.0, count: analysisValues.count)
+                    matchCount[fullMainData.match_num] = 0
+                }
+                for (index, value) in analysisValues.enumerated() {
+                    matchData[fullMainData.match_num]?[index] += Double(value)
+                }
+                matchCount[fullMainData.match_num]! += 1
+                dispatchGroup.leave()
+            }
+        }
+        
+        dispatchGroup.notify(queue: .main) {
+            for (matchNum, data) in matchData {
+                let count = matchCount[matchNum]!
+                let averages = data.map { $0 / Double(count) }
+                matchData[matchNum] = averages
+            }
+            completion(matchData)
+        }
+    }
+}

--- a/ios/beartracks/bearTracks/TeamStatController.swift
+++ b/ios/beartracks/bearTracks/TeamStatController.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum StatType {
-  case mean, first, median, third, decay
+    case mean, first, median, third, decay
 }
 
 class TeamStatController: ObservableObject {

--- a/ios/beartracks/bearTracks/TeamView.swift
+++ b/ios/beartracks/bearTracks/TeamView.swift
@@ -73,6 +73,15 @@ struct TeamView: View {
                             Text("Pit Scouting Data")
                         }
                     }
+                    if #available(iOS 18.0, *) {
+                        NavigationLink(destination: TeamHistoryGraph(teamNumber: Int(dataItems.targetTeam) ?? 0).navigationTitle("Charts")) {
+                            HStack {
+                                Text("Graphs")
+                            }
+                        }
+                    } else {
+                        Text("Upgrade to iOS 18 or later to see graphs.")
+                    }
 #endif
                     NavigationLink(destination: TeamViewStats(teamNum: dataItems.targetTeam).environmentObject(appState).navigationBarTitleDisplayMode(.automatic)) {
                         HStack {

--- a/ios/beartracks/bearTracks/TeamView.swift
+++ b/ios/beartracks/bearTracks/TeamView.swift
@@ -13,73 +13,75 @@ struct TeamView: View {
     
     var body: some View {
         VStack {
-            if !dataItems.teamMatches.isEmpty {
-                List {
+            
+            List {
 #if !os(watchOS)
-                    Section {
-                        VStack {
-                            if dataItems.teamData.isEmpty {
-                                HStack { Spacer(); ProgressView(); Spacer(); }
-                            } else {
-                                HStack {
-                                    VStack {
-                                        Text(String(dataItems.teamData.first?.record?.qual?.wins ?? 0))
-                                            .font(.title)
-                                        Text("Wins")
-                                    }
-                                    .frame(maxWidth: .infinity)
-                                    VStack {
-                                        Text(String(dataItems.teamData.first?.record?.qual?.losses ?? 0))
-                                            .font(.title)
-                                        Text("Losses")
-                                    }
-                                    .frame(maxWidth: .infinity)
-                                    VStack {
-                                        Text(String(dataItems.teamData.first?.record?.qual?.ties ?? 0))
-                                            .font(.title)
-                                        Text("Ties")
-                                    }
-                                    .frame(maxWidth: .infinity)
+                Text("\(appState.allTeams.nameShort(for: Int(dataItems.targetTeam) ?? 0))")
+                Section {
+                    VStack {
+                        if dataItems.teamData.isEmpty {
+                            HStack { Spacer(); VStack { ProgressView(); Text("Loading third-party data..."); }; Spacer(); }
+                        } else {
+                            HStack {
+                                VStack {
+                                    Text(String(dataItems.teamData.first?.record?.qual?.wins ?? 0))
+                                        .font(.title)
+                                    Text("Wins")
                                 }
-                                .padding(.bottom)
-                                HStack {
-                                    VStack {
-                                        Text(String(dataItems.teamData.first?.record?.qual?.rank ?? 99))
-                                            .font(.title)
-                                        Text("Rank")
-                                    }
-                                    .frame(maxWidth: .infinity)
-                                    VStack {
-                                        Text(String(dataItems.teamData.first?.record?.qual?.rps ?? 0))
-                                            .font(.title)
-                                        Text("RPs")
-                                    }
-                                    .frame(maxWidth: .infinity)
-                                    VStack {
-                                        Text(String(format: "%.1f", dataItems.teamData.first?.record?.qual?.rps_per_match ?? 0.0))
-                                            .font(.title)
-                                        Text("RPs / match")
-                                    }
-                                    .frame(maxWidth: .infinity)
+                                .frame(maxWidth: .infinity)
+                                VStack {
+                                    Text(String(dataItems.teamData.first?.record?.qual?.losses ?? 0))
+                                        .font(.title)
+                                    Text("Losses")
                                 }
+                                .frame(maxWidth: .infinity)
+                                VStack {
+                                    Text(String(dataItems.teamData.first?.record?.qual?.ties ?? 0))
+                                        .font(.title)
+                                    Text("Ties")
+                                }
+                                .frame(maxWidth: .infinity)
+                            }
+                            .padding(.bottom)
+                            HStack {
+                                VStack {
+                                    Text(String(dataItems.teamData.first?.record?.qual?.rank ?? 99))
+                                        .font(.title)
+                                    Text("Rank")
+                                }
+                                .frame(maxWidth: .infinity)
+                                VStack {
+                                    Text(String(dataItems.teamData.first?.record?.qual?.rps ?? 0))
+                                        .font(.title)
+                                    Text("RPs")
+                                }
+                                .frame(maxWidth: .infinity)
+                                VStack {
+                                    Text(String(format: "%.1f", dataItems.teamData.first?.record?.qual?.rps_per_match ?? 0.0))
+                                        .font(.title)
+                                    Text("RPs / match")
+                                }
+                                .frame(maxWidth: .infinity)
                             }
                         }
                     }
-                    Section {
+                }
+                Section {
 #if !os(watchOS)
-                        NavigationLink(destination: PitDataView(teamNumber: Int(dataItems.targetTeam) ?? 0)) {
-                            HStack {
-                                Text("Pit Scouting Data")
-                            }
-                        }
-#endif
-                        NavigationLink(destination: TeamViewStats(teamNum: dataItems.targetTeam).environmentObject(appState).navigationBarTitleDisplayMode(.automatic)) {
-                            HStack {
-                                Text("Additional Details")
-                            }
+                    NavigationLink(destination: PitDataView(teamNumber: Int(dataItems.targetTeam) ?? 0)) {
+                        HStack {
+                            Text("Pit Scouting Data")
                         }
                     }
 #endif
+                    NavigationLink(destination: TeamViewStats(teamNum: dataItems.targetTeam).environmentObject(appState).navigationBarTitleDisplayMode(.automatic)) {
+                        HStack {
+                            Text("Additional Details")
+                        }
+                    }
+                }
+#endif
+                if !dataItems.teamMatches.isEmpty {
                     Section {
                         ForEach(0..<dataItems.teamMatches.count, id: \.self) { index in
                             NavigationLink(destination: {
@@ -120,14 +122,15 @@ struct TeamView: View {
 #endif
                         }
                     }
-                }
-            } else {
-                if dataItems.loadComplete.0 && dataItems.loadComplete.1 && (dataItems.teamData.isEmpty || dataItems.teamMatches.isEmpty) {
-                    Label("Loading failed", systemImage: "xmark.seal.fill").navigationTitle("Team \(String(dataItems.targetTeam))")
                 } else {
-                    Text("Loading team...").navigationTitle("Team \(String(dataItems.targetTeam))")
+                    if dataItems.loadComplete.0 && dataItems.loadComplete.1 && (dataItems.teamData.isEmpty || dataItems.teamMatches.isEmpty) {
+                        Label("Match data loading failed, or there was no data found for this team.", systemImage: "xmark.seal.fill").navigationTitle("Team \(String(dataItems.targetTeam))")
+                    } else {
+                        HStack { Spacer(); ProgressView(); Spacer(); }
+                    }
                 }
             }
+            
         }
         .navigationTitle("Team \(String(dataItems.targetTeam))")
     }

--- a/ios/beartracks/bearTracks/TeamViewModel.swift
+++ b/ios/beartracks/bearTracks/TeamViewModel.swift
@@ -71,14 +71,7 @@ class TeamViewModel: ObservableObject {
     
     func fetchStatboticsTeamJson(completionBlock: @escaping (StatboticsTeamData) -> Void) {
         self.loadComplete.1 = false
-        guard
-            let url = URL(
-                string:
-                    "https://api.statbotics.io/v3/team_event/\(targetTeam)/\(UserDefaults().string(forKey: "season") ?? "2025")\(UserDefaults().string(forKey: "eventCode")?.lowercased() ?? "TEST")"
-            )
-        else {
-            return
-        }
+        guard let url = URL(string: "https://api.statbotics.io/v3/team_event/\(targetTeam)/\(UserDefaults().string(forKey: "season") ?? "2025")\(UserDefaults().string(forKey: "eventCode")?.lowercased() ?? "TEST")") else { return }
         
         var request = URLRequest(url: url)
         request.httpMethod = "GET"

--- a/ios/beartracks/bearTracks/Teams.swift
+++ b/ios/beartracks/bearTracks/Teams.swift
@@ -16,7 +16,7 @@ struct Teams: View {
     var body: some View {
         VStack {
             NavigationView {
-                if !appState.teamsList.isEmpty && !appState.teamsList[0].isEmpty {
+                if !appState.teamsList.isEmpty && !appState.teamsList[0].isEmpty && !appState.allTeams.isEmpty {
                     List {
                         ForEach(Array(appState.teamsList[0].enumerated()), id: \.element.team.team) { index, team in
                             NavigationLink(tag: index, selection: self.$selectedTeam, destination: {
@@ -42,6 +42,14 @@ struct Teams: View {
                                             .padding(.trailing)
                                             .frame(maxWidth: .infinity, alignment: .trailing)
                                     }
+#if !os(watchOS)
+                                    HStack {
+                                        Spacer()
+                                        Text("\(appState.allTeams.nameShort(for: team.team.team))")
+                                            .font(.body)
+                                            .padding(.trailing)
+                                    }
+#endif
                                     HStack {
                                         ProgressView(
                                             value: max(team.performanceValue(type: performanceValue) ?? 0, 0),

--- a/ios/beartracks/bearTracks/Teams.swift
+++ b/ios/beartracks/bearTracks/Teams.swift
@@ -177,15 +177,15 @@ struct Teams: View {
                                     .padding(.bottom)
                             }
                             .navigationTitle("Teams")
+                            .onAppear {
+                                appState.fetchTeamsJson()
+                            }
                         }
                     }
                 }
             }
         }
         .refreshable {
-            appState.fetchTeamsJson()
-        }
-        .onAppear {
             appState.fetchTeamsJson()
         }
     }

--- a/ios/beartracks/bearTracks/Teams.swift
+++ b/ios/beartracks/bearTracks/Teams.swift
@@ -188,6 +188,11 @@ struct Teams: View {
         .refreshable {
             appState.fetchTeamsJson()
         }
+#if targetEnvironment(macCatalyst)
+        .onAppear {
+            appState.fetchTeamsJson()
+        }
+#endif
     }
 }
 

--- a/ios/beartracks/beartracks-scout.xcodeproj/project.pbxproj
+++ b/ios/beartracks/beartracks-scout.xcodeproj/project.pbxproj
@@ -333,7 +333,7 @@
 				CODE_SIGN_ENTITLEMENTS = "beartracks-scout/beartracks-scout.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 125;
+				CURRENT_PROJECT_VERSION = 126;
 				DEVELOPMENT_ASSET_PATHS = "\"beartracks-scout/Preview Content\"";
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				ENABLE_PREVIEWS = YES;
@@ -353,7 +353,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.1;
+				MARKETING_VERSION = 6.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jayagra.beartracks-scout";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -370,7 +370,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "beartracks-scout/beartracks-scout.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 125;
+				CURRENT_PROJECT_VERSION = 126;
 				DEVELOPMENT_ASSET_PATHS = "\"beartracks-scout/Preview Content\"";
 				DEVELOPMENT_TEAM = D6MFYYVHA8;
 				ENABLE_PREVIEWS = YES;
@@ -390,7 +390,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.1;
+				MARKETING_VERSION = 6.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jayagra.beartracks-scout";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/ios/beartracks/beartracks-scout/ScoutingController.swift
+++ b/ios/beartracks/beartracks-scout/ScoutingController.swift
@@ -158,7 +158,7 @@ class ScoutingController: ObservableObject {
     }
     
     func resetControllerData() {
-        self.switches = (false, false, false, 0, 0, 0, 0)
+        self.switches = (false, false, false, 0, 0, 0, 0, false)
         self.teamNumber = "--"
         self.times = [0, 0, 0]
         self.matchTimes = []

--- a/ios/beartracks/beartracks-scout/ScoutingController.swift
+++ b/ios/beartracks/beartracks-scout/ScoutingController.swift
@@ -27,8 +27,8 @@ class ScoutingController: ObservableObject {
     @Published public var defense: String = "No"
     @Published public var driving: String = ""
     @Published public var overall: String = ""
-    @Published public var switches: (Bool, Bool, Bool, Int, Int, Int, Int) = (
-        false, false, false, 0, 0, 0, 0
+    @Published public var switches: (Bool, Bool, Bool, Int, Int, Int, Int, Bool) = (
+        false, false, false, 0, 0, 0, 0, false
         /*
          0 - park
          1 - climb
@@ -37,6 +37,7 @@ class ScoutingController: ObservableObject {
          4 - coral handled, auto period
          5 - auto period scores
          6 -
+         7 - auto leave bool
          */
     )
     @Published public var cards: (Bool, Bool) = (false, false)
@@ -83,6 +84,7 @@ class ScoutingController: ObservableObject {
         localTimeCopy.append(MatchTime(score_type: 9, intake: switches.0 ? 1 : 0, travel: switches.0 ? 1 : 0, outtake: switches.0 ? 1 : 0)) // park
         localTimeCopy.append(MatchTime(score_type: 10, intake: switches.1 ? 1 : 0, travel: switches.1 ? 1 : 0, outtake: switches.1 ? 1 : 0)) // climb
         localTimeCopy.append(MatchTime(score_type: 11, intake: switches.2 ? 1 : 0, travel: switches.2 ? 1 : 0, outtake: switches.2 ? 1 : 0)) // climb deep
+        localTimeCopy.append(MatchTime(score_type: 12, intake: switches.7 ? 1 : 0, travel: switches.7 ? 1 : 0, outtake: switches.7 ? 1 : 0)) // auto leave
         localTimeCopy.append(MatchTime(score_type: 14, intake: Double(switches.4), travel: Double(switches.4), outtake: Double(switches.4))) // algae handled auto
         localTimeCopy.append(MatchTime(score_type: 15, intake: Double(switches.5), travel: Double(switches.5), outtake: Double(switches.5))) // coral handled
         localTimeCopy.append(MatchTime(score_type: 13, intake: Double(switches.6), travel: Double(switches.6), outtake: Double(switches.6))) // auto scores

--- a/ios/beartracks/beartracks-scout/StartView.swift
+++ b/ios/beartracks/beartracks-scout/StartView.swift
@@ -62,6 +62,8 @@ struct StartView: View {
                         if controller.matchNumber != 0 && controller.teamNumber != "--" {
                             Section {
                                 Text("Autonomous Period")
+                                Toggle("Leave", isOn: $controller.switches.7)
+                                    .padding(.bottom)
                                 Stepper {
                                     Text("Coral handled (\(controller.switches.5))")
                                 } onIncrement: {

--- a/ios/beartracks/beartracks-scout/StartView.swift
+++ b/ios/beartracks/beartracks-scout/StartView.swift
@@ -63,7 +63,6 @@ struct StartView: View {
                             Section {
                                 Text("Autonomous Period")
                                 Toggle("Leave", isOn: $controller.switches.7)
-                                    .padding(.bottom)
                                 Stepper {
                                     Text("Coral handled (\(controller.switches.5))")
                                 } onIncrement: {

--- a/src/game_api.rs
+++ b/src/game_api.rs
@@ -306,10 +306,10 @@ pub async fn execute(pool: &db_main::Pool, season: String, event: String, team: 
 
 fn get_team(conn: db_main::Connection, season: String, event: String, team: String) -> Result<Team, rusqlite::Error> {
     if event == "ALL" {
-        let stmt = conn.prepare("SELECT analysis FROM main WHERE season=:season AND game!=:event AND team=:team;")?;
+        let stmt = conn.prepare("SELECT analysis FROM main WHERE season=:season AND game!=:event AND team=:team; ORDER BY id DESC")?;
         get_rows(stmt, [season, event, team])
     } else {
-        let stmt = conn.prepare("SELECT analysis FROM main WHERE season=:season AND event=:event AND team=:team;")?;
+        let stmt = conn.prepare("SELECT analysis FROM main WHERE season=:season AND event=:event AND team=:team; ORDER BY id DESC")?;
         get_rows(stmt, [season, event, team])
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -415,14 +415,14 @@ async fn manage_get_all_apn_tokens(db: web::Data<Databases>, user: db_auth::User
 }
 
 // data dump
-async fn manage_data_dump(db: web::Data<Databases>, user: db_auth::User, path: web::Path<String>) -> Result<HttpResponse, AWError> {
-    if user.admin == "true" {
+async fn manage_data_dump(db: web::Data<Databases>, /* user: db_auth::User,*/ path: web::Path<String>) -> Result<HttpResponse, AWError> {
+    // if user.admin == "true" {
         Ok(HttpResponse::Ok()
             .insert_header(("Cache-Control", "no-cache"))
             .json(db_main::execute(&db.main, db_main::MainData::GetAllData, path).await?))
-    } else {
-        Ok(unauthorized_response())
-    }
+    // } else {
+    //     Ok(unauthorized_response())
+    // }
 }
 
 async fn manage_refresh_cache(user: db_auth::User) -> Result<HttpResponse, AWError> {
@@ -936,7 +936,7 @@ async fn main() -> io::Result<()> {
             .wrap(
                 DefaultHeaders::new()
                     .add(("Cache-Control", "public, max-age=604800"))
-                    .add(("X-bearTracks", "6.1.0")),
+                    .add(("X-bearTracks", "6.1.1")),
             )
             /* src  endpoints */
             // GET individual files

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -33,7 +33,7 @@ pub fn means_i64(data: &Vec<i64>, first_wt: f64) -> Vec<i64> {
     if data.len() > 0 {
         let mut means: Vec<i64> = Vec::new();
         means.push(data.iter().sum::<i64>() / data.len() as i64);
-        means.push(((data[0] as f64 * first_wt) + (data.iter().sum::<i64>() as f64 * (1.0 - first_wt))) as i64 / data.len() as i64);
+        means.push(((data[0] as f64 * first_wt) + ((data.iter().sum::<i64>() as f64 / data.len() as f64) * (1.0 - first_wt))) as i64);
         return means;
     }
     return vec![0, 0];


### PR DESCRIPTION
Server Notes
- Fixes calculation of decaying averages
- Opens the data dump endpoint to non-manager users

iOS Notes
- Adds graphs with team performance (iOS 18+ only)
- Adds team names to most views
- Adds ability to view pit scouting data without waiting for match data
- Adds autonomous leaving indicators
- Prevents 5-digit team numbers from overflowing match list
- Fixes pit data expansion crash
- Fixes some data loading/screen flashing bugs
- Optimizes data loading
- Adds a checkbox for auto leave in Scout app