### PR TITLE
Fix blackjack bet not subtracting at beginning of round

### DIFF
--- a/src/casino.rs
+++ b/src/casino.rs
@@ -365,6 +365,7 @@ impl BlackjackSession {
             });
         // if dealer score is more than player score
         } else if self.game.player.score < self.game.dealer.score {
+            result = "LS".to_string();
         // draw
         } else {
             result = "DR".to_string();


### PR DESCRIPTION
Fixes a longstanding bug which allowed some players to cheat and refresh the page to get better cards and not lose the hand by subtracting the player's bet at the beginning of the round.